### PR TITLE
fix deprecated method usage

### DIFF
--- a/lib/active_record/postgres/constraints/railtie.rb
+++ b/lib/active_record/postgres/constraints/railtie.rb
@@ -27,8 +27,8 @@ if defined?(::Rails::Railtie)
           end
 
           def pg?
-            config = ActiveRecord::Base.connection_config
-            return true if config && config[:adapter].in?(%w[postgresql postgis])
+            config = ActiveRecord::Base.connection_db_config
+            return true if config && config.adapter.in?(%w[postgresql postgis])
 
             Rails.logger.warn do
               'Not applying Postgres Constraints patches to ActiveRecord ' \


### PR DESCRIPTION
#### Changes
* replace ActiveRecord::Base.connection_config with ActiveRecord::Base.connection_db_config to get rid of warning